### PR TITLE
Update documentation for viewing a single library

### DIFF
--- a/openapi/parameters.yaml
+++ b/openapi/parameters.yaml
@@ -159,13 +159,13 @@ queryId:
     type: string
 rows:
   name: rows
-  description: How many records to return for this request (default=10, maximum=200)
+  description: How many records to return for this request (default=10, maximum=2000)
   in: query
   required: false
   schema:
     type: integer
     default: 10
-    maximum: 200
+    maximum: 2000
 sort:
   name: sort
   description: >

--- a/openapi/services/biblib.yaml
+++ b/openapi/services/biblib.yaml
@@ -545,6 +545,7 @@ biblib-libraries:
         description:
           Duplicate library name exists
 biblib-libraries-library_id:
+  summary: Returns the metadata and contents of a specified library. Takes pagination and field arguments consistent with the "search" endpoint.
   get:
     summary: View a single library
     parameters:
@@ -552,6 +553,30 @@ biblib-libraries-library_id:
         description: Library ID
         required: true
         in: path
+        schema:
+          type: string
+      - name: start
+        description: starting entry
+        in: path
+        default: 0
+        schema:
+          type: int
+      - name: rows
+        description: number of entries to return
+        default: 20
+        in: path
+        schema:
+          type: int
+      - name: sort
+        description: entry sort order
+        in: path
+        default: 'date desc'
+        schema:
+          type: string
+      - name: fl
+        description: returned fields
+        in: path
+        default: 'bibcode'
         schema:
           type: string
     description: >

--- a/openapi/services/biblib.yaml
+++ b/openapi/services/biblib.yaml
@@ -555,24 +555,23 @@ biblib-libraries-library_id:
         schema:
           type: string
       - name: start
-        description: starting entry
+        description: starting document index
         in: query
         schema:
           type: int
           default: 0
       - name: rows
-        description: number of entries to return
+        description: number of documents to return
         in: query
         schema:
           type: int
           default: 20
       - name: sort
-        description: entry sort order
+        description: document sort order
         in: query
         schema:
           type: string
           default: 'date desc'
-
       - name: fl
         description: returned fields
         in: query
@@ -582,7 +581,7 @@ biblib-libraries-library_id:
 
     description: >
       View metadata and contents of a specific library.
-      Takes pagination and field arguments consistent with the "search" endpoint.
+      Takes pagination and field arguments consistent with the "search" endpoint to support sorting and paging for documents within a library.
     tags:
       - libraries
     security:

--- a/openapi/services/biblib.yaml
+++ b/openapi/services/biblib.yaml
@@ -546,7 +546,7 @@ biblib-libraries:
           Duplicate library name exists
 biblib-libraries-library_id:
   get:
-    summary: Returns the metadata and contents of a specified library. Takes pagination and field arguments consistent with the "search" endpoint.
+    summary: Returns a single library
     parameters:
       - name: library_id
         description: Library ID
@@ -582,6 +582,7 @@ biblib-libraries-library_id:
 
     description: >
       View metadata and contents of a specific library.
+      Takes pagination and field arguments consistent with the "search" endpoint.
     tags:
       - libraries
     security:

--- a/openapi/services/biblib.yaml
+++ b/openapi/services/biblib.yaml
@@ -558,27 +558,29 @@ biblib-libraries-library_id:
       - name: start
         description: starting entry
         in: path
-        default: 0
         schema:
           type: int
+          default: 0
       - name: rows
         description: number of entries to return
-        default: 20
         in: path
         schema:
           type: int
+          default: 20
       - name: sort
         description: entry sort order
         in: path
-        default: 'date desc'
         schema:
           type: string
+          default: 'date desc'
+
       - name: fl
         description: returned fields
         in: path
-        default: 'bibcode'
         schema:
           type: string
+          default: 'bibcode'
+
     description: >
       View metadata and contents of a specific library.
     tags:

--- a/openapi/services/biblib.yaml
+++ b/openapi/services/biblib.yaml
@@ -545,9 +545,8 @@ biblib-libraries:
         description:
           Duplicate library name exists
 biblib-libraries-library_id:
-  summary: Returns the metadata and contents of a specified library. Takes pagination and field arguments consistent with the "search" endpoint.
   get:
-    summary: View a single library
+    summary: Returns the metadata and contents of a specified library. Takes pagination and field arguments consistent with the "search" endpoint.
     parameters:
       - name: library_id
         description: Library ID
@@ -557,26 +556,26 @@ biblib-libraries-library_id:
           type: string
       - name: start
         description: starting entry
-        in: path
+        in: query
         schema:
           type: int
           default: 0
       - name: rows
         description: number of entries to return
-        in: path
+        in: query
         schema:
           type: int
           default: 20
       - name: sort
         description: entry sort order
-        in: path
+        in: query
         schema:
           type: string
           default: 'date desc'
 
       - name: fl
         description: returned fields
-        in: path
+        in: query
         schema:
           type: string
           default: 'bibcode'

--- a/openapi/services/biblib.yaml
+++ b/openapi/services/biblib.yaml
@@ -546,7 +546,7 @@ biblib-libraries:
           Duplicate library name exists
 biblib-libraries-library_id:
   get:
-    summary: Returns a single library
+    summary: View a single library
     parameters:
       - name: library_id
         description: Library ID


### PR DESCRIPTION
- documents optional fields for viewing a single library.
  - `start`
  - `rows`
  - `sort`
  - `fl`

These fields follow the syntax for the `/search` endpoint