### PR TITLE
Update 'Bearer TOKEN' in api docs

### DIFF
--- a/openapi/services/solr.yaml
+++ b/openapi/services/solr.yaml
@@ -39,7 +39,7 @@ search-bigquery:
         bibcodes="bibcode\n1907AN....174...59.\n1908PA.....16..445.\n1989LNP...334..242S"
         r = requests.post('https://api.adsabs.harvard.edu/v1/search/bigquery',
              params={'q':'*:*', 'wt':'json', 'fq':'{!bitset}', 'fl':'bibcode'},
-             headers={'Authorization': 'Bearer:TOKEN'},
+             headers={'Authorization': 'Bearer TOKEN'},
              data=bibcodes)
       ```
 

--- a/openapi/services/vault.yaml
+++ b/openapi/services/vault.yaml
@@ -514,7 +514,7 @@ vault-query:
       ## Example request
 
       ```bash
-        $ curl 'https://api.adsabs.harvard.edu/v1/vault/query' -H 'Authorization: Bearer:TOKEN' \
+        $ curl 'https://api.adsabs.harvard.edu/v1/vault/query' -H 'Authorization: Bearer TOKEN' \
           -X POST -d $'{"q":"*:*", "bigquery": "bibcode\\n2015IAUGA..2257982A\\n2015IAUGA..2257768A\\n2015IAUGA..2257639R", "fq": "{!bitset}"}' \
           -H 'Content-Type: application/json'
 


### PR DESCRIPTION
Removed instances where 'Bearer: TOKEN' was found in api documentation; corrected them to 'Bearer TOKEN' by removing the colon. 